### PR TITLE
[bugfix] adds typescript livescript as devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,9 @@
   "dependencies": {
     "angular2": "2.0.0-alpha.46",
     "systemjs": "^0.19.5"
+  },
+  "devDependencies": {
+    "live-server": "^0.8.2",
+    "typescript": "^1.6.2"
   }
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -6,7 +6,6 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "removeComments": false,
-    "noImplicitAny": true,
-    "suppressImplicitAnyIndexErrors": true
+    "noImplicitAny": false
   }
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -6,6 +6,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "removeComments": false,
-    "noImplicitAny": false
+    "noImplicitAny": true,
+    "suppressImplicitAnyIndexErrors": true
   }
 }


### PR DESCRIPTION
@DanWahlin I also noticed a similar issue as @garciasa

Adding typescript / live-server as development dependencies seems to solve the issue.

```bash
npm init -y
npm i angular2@2.0.0-alpha.44 systemjs@0.19.2 --save --save-exact
npm i typescript live-server --save-dev
```
See: https://angular.io/docs/ts/latest/quickstart.html