### PR TITLE
Fix path to app in systemjs.config.js

### DIFF
--- a/src/systemjs.config.js
+++ b/src/systemjs.config.js
@@ -2,7 +2,7 @@
 
   // map tells the System loader where to look for things
   var map = {
-    'app':                        'app', // 'dist',
+    'app':                        'src/app', // 'dist',
     'rxjs':                       'node_modules/rxjs',
     '@angular':                   'node_modules/@angular'
   };


### PR DESCRIPTION
`app` is contained in `src` folder, not in (non-existent) `app` folder in the root.