### PR TITLE
Fix for broken title link

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -43,7 +43,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
               </button>
-              <a href="/src">
+              <a href="/">
                 <img src="images/people.png" alt="logo">
                 <span class="app-title">Customer Manager</span>
               </a>


### PR DESCRIPTION
When you click the "Customer Manager" nav title link, the page breaks as it seems like you are going to a "/src" route.

Even though the index is in `src` folder, it's root from the web server point of view.

So, I changed the link to point to `/`.